### PR TITLE
Require biometric or custom PIN when launching app

### DIFF
--- a/SeedTool/AuthenticationManager.swift
+++ b/SeedTool/AuthenticationManager.swift
@@ -1,0 +1,100 @@
+//
+//  AuthenticationManager.swift
+//  Gordian Seed Tool
+//
+//  Created by Authentication System
+//
+
+import SwiftUI
+import Observation
+
+@Observable
+class AuthenticationManager {
+    var isAuthenticated = false
+    var isAuthenticationRequired = false
+    var authenticationAttempts = 0
+    private let maxAttempts = 5
+    
+    private let biometricManager = BiometricAuthManager()
+    private let settings: Settings
+    
+    init(settings: Settings) {
+        self.settings = settings
+        updateAuthenticationRequirement()
+    }
+    
+    func updateAuthenticationRequirement() {
+        isAuthenticationRequired = settings.authenticationEnabled && 
+                                 (settings.biometricAuthEnabled || settings.hasPINCode)
+    }
+    
+    func authenticateWithBiometrics() async -> Bool {
+        guard settings.biometricAuthEnabled && biometricManager.isBiometricAvailable else {
+            return false
+        }
+        
+        let result = await biometricManager.authenticateWithBiometrics()
+        switch result {
+        case .success(let success):
+            if success {
+                isAuthenticated = true
+                authenticationAttempts = 0
+            }
+            return success
+        case .failure:
+            return false
+        }
+    }
+    
+    func authenticateWithPIN(_ pin: String) -> Bool {
+        guard let storedPIN = KeychainHelper.shared.retrievePINCode() else {
+            return false
+        }
+        
+        if pin == storedPIN {
+            isAuthenticated = true
+            authenticationAttempts = 0
+            return true
+        } else {
+            authenticationAttempts += 1
+            return false
+        }
+    }
+    
+    func setupPIN(_ pin: String) -> Bool {
+        let success = KeychainHelper.shared.storePINCode(pin)
+        if success {
+            settings.authenticationEnabled = true
+        }
+        return success
+    }
+    
+    func removePIN() -> Bool {
+        let success = KeychainHelper.shared.deletePINCode()
+        if success && !settings.biometricAuthEnabled {
+            settings.authenticationEnabled = false
+        }
+        return success
+    }
+    
+    func logout() {
+        isAuthenticated = false
+        authenticationAttempts = 0
+    }
+    
+    var isBiometricAvailable: Bool {
+        biometricManager.isBiometricAvailable
+    }
+    
+    var biometricDisplayName: String {
+        biometricManager.biometricDisplayName
+    }
+    
+    var isLockedOut: Bool {
+        authenticationAttempts >= maxAttempts
+    }
+    
+    var remainingAttempts: Int {
+        max(0, maxAttempts - authenticationAttempts)
+    }
+} 

--- a/SeedTool/AuthenticationSettingsView.swift
+++ b/SeedTool/AuthenticationSettingsView.swift
@@ -1,0 +1,200 @@
+//
+//  AuthenticationSettingsView.swift
+//  Gordian Seed Tool
+//
+//  Created by Authentication System
+//
+
+import SwiftUI
+
+struct AuthenticationSettingsView: View {
+    @Environment(Settings.self) private var settings
+    @State private var authManager: AuthenticationManager
+    @State private var showPINSetup = false
+    @State private var showAlert = false
+    @State private var alertTitle = ""
+    @State private var alertMessage = ""
+    
+    init(settings: Settings) {
+        self._authManager = State(initialValue: AuthenticationManager(settings: settings))
+    }
+    
+    var body: some View {
+        List {
+            Section {
+                Toggle("Enable Authentication", isOn: Binding(
+                    get: { settings.authenticationEnabled },
+                    set: { newValue in
+                        if !newValue {
+                            // Disable all authentication
+                            settings.authenticationEnabled = false
+                            settings.biometricAuthEnabled = false
+                            _ = authManager.removePIN()
+                        } else {
+                            settings.authenticationEnabled = true
+                        }
+                        authManager.updateAuthenticationRequirement()
+                    }
+                ))
+            } header: {
+                Text("Security")
+            } footer: {
+                Text("When enabled, you'll need to authenticate each time you open the app.")
+            }
+            
+            if settings.authenticationEnabled {
+                Section("Authentication Methods") {
+                    // Biometric Authentication
+                    if authManager.isBiometricAvailable {
+                        HStack {
+                            Image(systemName: biometricIcon)
+                                .foregroundColor(.blue)
+                                .frame(width: 24)
+                            
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(authManager.biometricDisplayName)
+                                    .font(.body)
+                                Text("Use \(authManager.biometricDisplayName.lowercased()) to unlock")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            
+                            Spacer()
+                            
+                            Toggle("", isOn: Binding(
+                                get: { settings.biometricAuthEnabled },
+                                set: { settings.biometricAuthEnabled = $0 }
+                            )).labelsHidden()
+                        }
+                    } else {
+                        HStack {
+                            Image(systemName: "exclamationmark.triangle")
+                                .foregroundColor(.orange)
+                                .frame(width: 24)
+                            
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Biometric Authentication")
+                                    .font(.body)
+                                Text("Not available on this device")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                    
+                    // PIN Code
+                    HStack {
+                        Image(systemName: "number.square")
+                            .foregroundColor(.green)
+                            .frame(width: 24)
+                        
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("PIN Code")
+                                .font(.body)
+                            Text(settings.hasPINCode ? "PIN is set up" : "No PIN set up")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        
+                        Spacer()
+                        
+                        if settings.hasPINCode {
+                            Button("Change") {
+                                showPINSetup = true
+                            }
+                            .font(.caption)
+                            .foregroundColor(.blue)
+                        } else {
+                            Button("Set Up") {
+                                showPINSetup = true
+                            }
+                            .font(.caption)
+                            .foregroundColor(.blue)
+                        }
+                    }
+                    
+                    if settings.hasPINCode {
+                        Button("Remove PIN") {
+                            showRemovePINAlert()
+                        }
+                        .foregroundColor(.red)
+                    }
+                }
+                
+                Section {
+                    HStack {
+                        Image(systemName: "info.circle")
+                            .foregroundColor(.blue)
+                        Text("Authentication Status")
+                        Spacer()
+                        Text(authenticationStatusText)
+                            .foregroundColor(.secondary)
+                            .font(.caption)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Authentication")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showPINSetup) {
+            PINSetupView(authManager: authManager) {
+                authManager.updateAuthenticationRequirement()
+            }
+        }
+        .alert(alertTitle, isPresented: $showAlert) {
+            if alertTitle == "Remove PIN" {
+                Button("Remove", role: .destructive) {
+                    removePIN()
+                }
+                Button("Cancel", role: .cancel) { }
+            } else {
+                Button("OK") { }
+            }
+        } message: {
+            Text(alertMessage)
+        }
+    }
+    
+    private var biometricIcon: String {
+        switch authManager.biometricDisplayName {
+        case "Face ID":
+            return "faceid"
+        case "Touch ID":
+            return "touchid"
+        case "Optic ID":
+            return "opticid"
+        default:
+            return "person.badge.key"
+        }
+    }
+    
+    private var authenticationStatusText: String {
+        if settings.biometricAuthEnabled && settings.hasPINCode {
+            return "Both enabled"
+        } else if settings.biometricAuthEnabled {
+            return "Biometric only"
+        } else if settings.hasPINCode {
+            return "PIN only"
+        } else {
+            return "None configured"
+        }
+    }
+    
+    private func showRemovePINAlert() {
+        alertTitle = "Remove PIN"
+        alertMessage = "Are you sure you want to remove your PIN? This will disable PIN authentication."
+        showAlert = true
+    }
+    
+    private func removePIN() {
+        if authManager.removePIN() {
+            alertTitle = "Success"
+            alertMessage = "PIN has been removed successfully."
+        } else {
+            alertTitle = "Error"
+            alertMessage = "Failed to remove PIN. Please try again."
+        }
+        authManager.updateAuthenticationRequirement()
+        showAlert = true
+    }
+} 

--- a/SeedTool/AuthenticationView.swift
+++ b/SeedTool/AuthenticationView.swift
@@ -1,0 +1,212 @@
+//
+//  AuthenticationView.swift
+//  Gordian Seed Tool
+//
+//  Created by Authentication System
+//
+
+import SwiftUI
+
+struct AuthenticationView: View {
+    @Environment(Settings.self) private var settings
+    let authManager: AuthenticationManager
+    @State private var pin = ""
+    @State private var showError = false
+    @State private var errorMessage = ""
+    @State private var showPINSetup = false
+    @State private var authenticationInProgress = false
+    
+    init(authManager: AuthenticationManager) {
+        self.authManager = authManager
+    }
+    
+    var body: some View {
+        VStack(spacing: 40) {
+            Spacer()
+            
+            // App Icon and Title
+            VStack(spacing: 20) {
+                Image(systemName: "shield.checkered")
+                    .font(.system(size: 80))
+                    .foregroundColor(.blue)
+                
+                Text("Gordian Seed Tool")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                
+                Text("Authentication Required")
+                    .font(.headline)
+                    .foregroundColor(.secondary)
+            }
+            
+            VStack(spacing: 25) {
+                // Biometric Authentication Button
+                if settings.biometricAuthEnabled && authManager.isBiometricAvailable {
+                    Button {
+                        Task {
+                            await authenticateWithBiometrics()
+                        }
+                    } label: {
+                        HStack {
+                            Image(systemName: biometricIcon)
+                                .font(.title2)
+                            Text("Unlock with \(authManager.biometricDisplayName)")
+                                .font(.headline)
+                        }
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .cornerRadius(12)
+                    }
+                    .disabled(authenticationInProgress || authManager.isLockedOut)
+                }
+                
+                // PIN Authentication
+                if settings.hasPINCode {
+                    VStack(spacing: 15) {
+                        PINInputView(
+                            pin: $pin,
+                            isSecure: true,
+                            placeholder: "Enter PIN"
+                        )
+                        
+                        Button(action: authenticateWithPIN) {
+                            Text("Unlock")
+                                .font(.headline)
+                                .foregroundColor(.white)
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(pin.count >= 4 ? Color.green : Color.gray)
+                                .cornerRadius(12)
+                        }
+                        .disabled(pin.count < 4 || authenticationInProgress || authManager.isLockedOut)
+                    }
+                }
+                
+                // Setup PIN Button (if no authentication is set up)
+                if !settings.biometricAuthEnabled && !settings.hasPINCode {
+                    VStack(spacing: 15) {
+                        Text("No authentication method is set up")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                        
+                        Button("Set Up PIN Code") {
+                            showPINSetup = true
+                        }
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .cornerRadius(12)
+                    }
+                }
+                
+                // Error Message
+                if showError {
+                    Text(errorMessage)
+                        .foregroundColor(.red)
+                        .font(.caption)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
+                }
+                
+                // Lockout Message
+                if authManager.isLockedOut {
+                    VStack(spacing: 5) {
+                        Text("Too many failed attempts")
+                            .foregroundColor(.red)
+                            .font(.headline)
+                        Text("Please restart the app to try again")
+                            .foregroundColor(.secondary)
+                            .font(.caption)
+                    }
+                    .multilineTextAlignment(.center)
+                } else if authManager.authenticationAttempts > 0 {
+                    Text("\(authManager.remainingAttempts) attempts remaining")
+                        .foregroundColor(.orange)
+                        .font(.caption)
+                }
+            }
+            
+            Spacer()
+        }
+        .padding()
+        .background(Color(.systemBackground))
+        .sheet(isPresented: $showPINSetup) {
+            PINSetupView(authManager: authManager) {
+                authManager.updateAuthenticationRequirement()
+            }
+        }
+        .onAppear {
+            // Auto-trigger biometric authentication if available and enabled
+            if settings.biometricAuthEnabled && authManager.isBiometricAvailable {
+                Task {
+                    await authenticateWithBiometrics()
+                }
+            }
+        }
+    }
+    
+    private var biometricIcon: String {
+        switch authManager.biometricDisplayName {
+        case "Face ID":
+            return "faceid"
+        case "Touch ID":
+            return "touchid"
+        case "Optic ID":
+            return "opticid"
+        default:
+            return "person.badge.key"
+        }
+    }
+    
+    private func authenticateWithBiometrics() async {
+        guard !authenticationInProgress else { return }
+        
+        authenticationInProgress = true
+        showError = false
+        
+        let success = await authManager.authenticateWithBiometrics()
+        
+        authenticationInProgress = false
+        
+        if !success && !authManager.isAuthenticated {
+            showError(message: "Biometric authentication failed. Please try again or use your PIN.")
+        }
+    }
+    
+    private func authenticateWithPIN() {
+        guard !authenticationInProgress else { return }
+        
+        authenticationInProgress = true
+        showError = false
+        
+        let success = authManager.authenticateWithPIN(pin)
+        
+        authenticationInProgress = false
+        
+        if success {
+            pin = ""
+        } else {
+            pin = ""
+            if authManager.isLockedOut {
+                showError(message: "Too many failed attempts. Please restart the app.")
+            } else {
+                showError(message: "Incorrect PIN. \(authManager.remainingAttempts) attempts remaining.")
+            }
+        }
+    }
+    
+    private func showError(message: String) {
+        errorMessage = message
+        showError = true
+        
+        // Hide error after 3 seconds
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            showError = false
+        }
+    }
+} 

--- a/SeedTool/BiometricAuthManager.swift
+++ b/SeedTool/BiometricAuthManager.swift
@@ -1,0 +1,137 @@
+//
+//  BiometricAuthManager.swift
+//  Gordian Seed Tool
+//
+//  Created by Authentication System
+//
+
+import Foundation
+import LocalAuthentication
+import SwiftUI
+
+@Observable
+class BiometricAuthManager {
+    enum BiometricType {
+        case none
+        case touchID
+        case faceID
+        case opticID
+    }
+    
+    enum AuthenticationError: LocalizedError {
+        case biometricNotAvailable
+        case biometricNotEnrolled
+        case authenticationFailed
+        case userCancel
+        case userFallback
+        case systemCancel
+        case passcodeNotSet
+        case unknown
+        
+        var errorDescription: String? {
+            switch self {
+            case .biometricNotAvailable:
+                return "Biometric authentication is not available on this device."
+            case .biometricNotEnrolled:
+                return "No biometric data is enrolled. Please set up Face ID or Touch ID in Settings."
+            case .authenticationFailed:
+                return "Authentication failed. Please try again."
+            case .userCancel:
+                return "Authentication was cancelled by user."
+            case .userFallback:
+                return "User selected fallback authentication method."
+            case .systemCancel:
+                return "Authentication was cancelled by system."
+            case .passcodeNotSet:
+                return "Device passcode is not set. Please set up a passcode in Settings."
+            case .unknown:
+                return "An unknown error occurred during authentication."
+            }
+        }
+    }
+    
+    var biometricType: BiometricType {
+        let context = LAContext()
+        var error: NSError?
+        
+        guard context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
+            return .none
+        }
+        
+        switch context.biometryType {
+        case .touchID:
+            return .touchID
+        case .faceID:
+            return .faceID
+        case .opticID:
+            return .opticID
+        default:
+            return .none
+        }
+    }
+    
+    var isBiometricAvailable: Bool {
+        let context = LAContext()
+        return context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
+    }
+    
+    var biometricDisplayName: String {
+        switch biometricType {
+        case .touchID:
+            return "Touch ID"
+        case .faceID:
+            return "Face ID"
+        case .opticID:
+            return "Optic ID"
+        case .none:
+            return "Biometric"
+        }
+    }
+    
+    func authenticateWithBiometrics() async -> Result<Bool, AuthenticationError> {
+        let context = LAContext()
+        var error: NSError?
+        
+        guard context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
+            if let error = error {
+                switch error.code {
+                case LAError.biometryNotAvailable.rawValue:
+                    return .failure(.biometricNotAvailable)
+                case LAError.biometryNotEnrolled.rawValue:
+                    return .failure(.biometricNotEnrolled)
+                case LAError.passcodeNotSet.rawValue:
+                    return .failure(.passcodeNotSet)
+                default:
+                    return .failure(.unknown)
+                }
+            }
+            return .failure(.biometricNotAvailable)
+        }
+        
+        do {
+            let reason = "Authenticate to access your secure data"
+            let success = try await context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason)
+            return .success(success)
+        } catch {
+            let laError = error as! LAError
+            switch laError.code {
+            case .authenticationFailed:
+                return .failure(.authenticationFailed)
+            case .userCancel:
+                return .failure(.userCancel)
+            case .userFallback:
+                return .failure(.userFallback)
+            case .systemCancel:
+                return .failure(.systemCancel)
+            case .biometryNotAvailable:
+                return .failure(.biometricNotAvailable)
+            case .biometryNotEnrolled:
+                return .failure(.biometricNotEnrolled)
+            case .passcodeNotSet:
+                return .failure(.passcodeNotSet)
+            default:
+                return .failure(.unknown)
+            }
+        }
+    }
+} 

--- a/SeedTool/KeychainHelper.swift
+++ b/SeedTool/KeychainHelper.swift
@@ -1,0 +1,68 @@
+//
+//  KeychainHelper.swift
+//  Gordian Seed Tool
+//
+//  Created by Authentication System
+//
+
+import Foundation
+import Security
+
+class KeychainHelper {
+    static let shared = KeychainHelper()
+    private let pinCodeKey = "user_pin_code"
+    
+    private init() {}
+    
+    func storePINCode(_ pin: String) -> Bool {
+        guard let data = pin.data(using: .utf8) else { return false }
+        
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: pinCodeKey,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+        
+        // Delete any existing item
+        SecItemDelete(query as CFDictionary)
+        
+        // Add the new item
+        let status = SecItemAdd(query as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+    
+    func retrievePINCode() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: pinCodeKey,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let pin = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        
+        return pin
+    }
+    
+    func deletePINCode() -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: pinCodeKey
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+    
+    func hasPINCode() -> Bool {
+        return retrievePINCode() != nil
+    }
+} 

--- a/SeedTool/PINSetupView.swift
+++ b/SeedTool/PINSetupView.swift
@@ -1,0 +1,170 @@
+//
+//  PINSetupView.swift
+//  Gordian Seed Tool
+//
+//  Created by Authentication System
+//
+
+import SwiftUI
+
+struct PINSetupView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var pin = ""
+    @State private var confirmPin = ""
+    @State private var showError = false
+    @State private var errorMessage = ""
+    @State private var step: SetupStep = .enterPIN
+    
+    let authManager: AuthenticationManager
+    let onComplete: () -> Void
+    
+    enum SetupStep {
+        case enterPIN
+        case confirmPIN
+    }
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 30) {
+                VStack(spacing: 10) {
+                    Image(systemName: "lock.shield")
+                        .font(.system(size: 60))
+                        .foregroundColor(.blue)
+                    
+                    Text("Set Up PIN Code")
+                        .font(.title)
+                        .fontWeight(.bold)
+                    
+                    Text(step == .enterPIN ? "Enter a 4-6 digit PIN" : "Confirm your PIN")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                
+                VStack(spacing: 20) {
+                    PINInputView(
+                        pin: step == .enterPIN ? $pin : $confirmPin,
+                        isSecure: true,
+                        placeholder: step == .enterPIN ? "Enter PIN" : "Confirm PIN"
+                    )
+                    
+                    if showError {
+                        Text(errorMessage)
+                            .foregroundColor(.red)
+                            .font(.caption)
+                    }
+                }
+                
+                VStack(spacing: 15) {
+                    Button(action: handleContinue) {
+                        Text(step == .enterPIN ? "Continue" : "Set PIN")
+                            .font(.headline)
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(isValidPIN ? Color.blue : Color.gray)
+                            .cornerRadius(10)
+                    }
+                    .disabled(!isValidPIN)
+                    
+                    if step == .confirmPIN {
+                        Button("Back") {
+                            step = .enterPIN
+                            confirmPin = ""
+                            showError = false
+                        }
+                        .foregroundColor(.blue)
+                    }
+                }
+                
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+    
+    private var isValidPIN: Bool {
+        let currentPin = step == .enterPIN ? pin : confirmPin
+        return currentPin.count >= 4 && currentPin.count <= 6 && currentPin.allSatisfy(\.isNumber)
+    }
+    
+    private func handleContinue() {
+        showError = false
+        
+        switch step {
+        case .enterPIN:
+            if pin.count < 4 || pin.count > 6 {
+                showError(message: "PIN must be 4-6 digits")
+                return
+            }
+            step = .confirmPIN
+            
+        case .confirmPIN:
+            if confirmPin != pin {
+                showError(message: "PINs don't match")
+                return
+            }
+            
+            if authManager.setupPIN(pin) {
+                onComplete()
+                dismiss()
+            } else {
+                showError(message: "Failed to save PIN. Please try again.")
+            }
+        }
+    }
+    
+    private func showError(message: String) {
+        errorMessage = message
+        showError = true
+    }
+}
+
+struct PINInputView: View {
+    @Binding var pin: String
+    let isSecure: Bool
+    let placeholder: String
+    
+    var body: some View {
+        VStack {
+            if isSecure {
+                SecureField(placeholder, text: $pin)
+                    .keyboardType(.numberPad)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .font(.title2)
+                    .multilineTextAlignment(.center)
+            } else {
+                TextField(placeholder, text: $pin)
+                    .keyboardType(.numberPad)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .font(.title2)
+                    .multilineTextAlignment(.center)
+            }
+            
+            // PIN dots visualization
+            HStack(spacing: 10) {
+                ForEach(0..<6, id: \.self) { index in
+                    Circle()
+                        .fill(index < pin.count ? Color.blue : Color.gray.opacity(0.3))
+                        .frame(width: 12, height: 12)
+                }
+            }
+            .padding(.top, 5)
+        }
+    }
+}
+
+#Preview {
+    PINSetupView(
+        authManager: AuthenticationManager(settings: Settings(storage: MockSettingsStorage())),
+        onComplete: {}
+    )
+} 

--- a/SeedTool/SeedToolApp.swift
+++ b/SeedTool/SeedToolApp.swift
@@ -43,12 +43,15 @@ struct SeedToolApp: App {
     @UIApplicationDelegateAdaptor private var appDelegate: AppDelegate
     @State private var model: Model
     @State private var settings: Settings
+    @State private var authManager: AuthenticationManager
     
     init() {
         let settings = globalSettings
         let model = Model(settings: settings)
+        let authManager = AuthenticationManager(settings: settings)
         self.settings = settings
         self.model = model
+        self.authManager = authManager
     }
     
     var body: some Scene {
@@ -57,6 +60,7 @@ struct SeedToolApp: App {
                 .tapToDismiss()
                 .environment(model)
                 .environment(settings)
+                .environment(authManager)
                 .onAppear {
                     disableHardwareKeyboards()
                 }

--- a/SeedTool/Settings.swift
+++ b/SeedTool/Settings.swift
@@ -60,6 +60,22 @@ final class Settings {
             storage.showDeveloperFunctions = showDeveloperFunctions
         }
     }
+    
+    var authenticationEnabled: Bool {
+        didSet {
+            storage.authenticationEnabled = authenticationEnabled
+        }
+    }
+    
+    var biometricAuthEnabled: Bool {
+        didSet {
+            storage.biometricAuthEnabled = biometricAuthEnabled
+        }
+    }
+    
+    var hasPINCode: Bool {
+        storage.hasPINCode
+    }
 
     init(storage: SettingsStorage) {
         UserDefaults.standard.register(
@@ -76,6 +92,8 @@ final class Settings {
         syncToCloud = storage.syncToCloud
         needsMergeWithCloud = storage.needsMergeWithCloud
         showDeveloperFunctions = storage.showDeveloperFunctions
+        authenticationEnabled = storage.authenticationEnabled
+        biometricAuthEnabled = storage.biometricAuthEnabled
     }
 }
 
@@ -87,6 +105,9 @@ protocol SettingsStorage {
     var syncToCloud: SyncToCloud { get set }
     var needsMergeWithCloud: Bool { get set }
     var showDeveloperFunctions: Bool { get set }
+    var authenticationEnabled: Bool { get set }
+    var biometricAuthEnabled: Bool { get set }
+    var hasPINCode: Bool { get }
 }
 
 struct MockSettingsStorage: SettingsStorage {
@@ -97,6 +118,9 @@ struct MockSettingsStorage: SettingsStorage {
     var syncToCloud = SyncToCloud.on
     var needsMergeWithCloud = true
     var showDeveloperFunctions = true
+    var authenticationEnabled = false
+    var biometricAuthEnabled = false
+    var hasPINCode: Bool { false }
 }
 
 extension UserDefaults: SettingsStorage {
@@ -132,6 +156,20 @@ extension UserDefaults: SettingsStorage {
     var showDeveloperFunctions: Bool {
         get { bool(forKey: "showDeveloperFunctions") }
         set { setValue(newValue, forKey: "showDeveloperFunctions") }
+    }
+    
+    var authenticationEnabled: Bool {
+        get { bool(forKey: "authenticationEnabled") }
+        set { setValue(newValue, forKey: "authenticationEnabled") }
+    }
+    
+    var biometricAuthEnabled: Bool {
+        get { bool(forKey: "biometricAuthEnabled") }
+        set { setValue(newValue, forKey: "biometricAuthEnabled") }
+    }
+    
+    var hasPINCode: Bool {
+        KeychainHelper.shared.hasPINCode()
     }
 }
 

--- a/SeedTool/SettingsPanel.swift
+++ b/SeedTool/SettingsPanel.swift
@@ -74,6 +74,12 @@ struct SettingsPanel: View {
                         .font(.footnote)
                     }
                     
+                    AppGroupBox("Security") {
+                        NavigationLink("Authentication") {
+                            AuthenticationSettingsView(settings: settings)
+                        }
+                    }
+                    
                     AppGroupBox("Advanced") {
                         VStack(alignment: .leading) {
                             @Bindable var settings = settings


### PR DESCRIPTION
The Seed Tool is by far the best app of its kind on the market, thank you for building it!

After an unfortunate incident involving my son and some thieves who took his phone and demanded the passcode at gunpoint, I have come to realize just how powerful the iPhone passcode is. By default, the passcode can always substitute for biometrics, like for example if you long-press on an app icon and "Require FaceID", it doesn't actually, you know, require FaceID. 

So, Claude and I set out to fix this (one prompt, about 10 minutes). This PR lets the user optionally require FaceID or a **custom** PIN code to open the app. I am not an iOS dev, and I am unsure how much **actual** security this adds, but it would certainly stop garden variety bad guys who have your phone and your passcode, at least for a while, perhaps long enough for you to remotely wipe the device. 

Feel free to close if you are not interested, I totally understand, but perhaps others will find it useful as well.

![UI](https://github.com/user-attachments/assets/a5eb560a-2d2a-4f9c-a3ce-7c64dc766e1f)
